### PR TITLE
Client create collection via http client

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -25,7 +25,7 @@ func (cl *CollectionsClient) List() *CollectionsListClient {
 	return newCollectionListClient(cl.sl)
 }
 
-func (cl *CollectionsClient) Create(name CollectionName) *CollectionsCreateClient {
+func (cl *CollectionsClient) Create(name string) *CollectionsCreateClient {
 	return newCollectionsCreateClient(cl.sl, name)
 }
 
@@ -129,9 +129,9 @@ type CollectionsCreateClient struct {
 	sl *sling.Sling
 }
 
-func newCollectionsCreateClient(sl *sling.Sling, name CollectionName) *CollectionsCreateClient {
+func newCollectionsCreateClient(sl *sling.Sling, name string) *CollectionsCreateClient {
 	data := struct {
-		Name CollectionName `json:"name"`
+		Name string `json:"name"`
 	}{Name: name}
 
 	copy := sl.New()

--- a/collections.go
+++ b/collections.go
@@ -40,7 +40,7 @@ func newCollectionsGetClient(sl *sling.Sling, id CollectionID) *CollectionsGetCl
 	return &CollectionsGetClient{sl: copy}
 }
 
-// Do makes the actual request for fetching said collection info.
+// Do make the actual request for fetching said collection info.
 func (cl *CollectionsGetClient) Do(ctx context.Context) (*Collection, error) {
 	success := &struct {
 		Data *Collection `json:"data"`
@@ -71,7 +71,7 @@ func newCollectionListClient(sl *sling.Sling) *CollectionsListClient {
 // CollectionsListFn is the type of function called by [CollectionsListClient.Do] for every new collecion it finds.
 type CollectionsListFn func(*Collection, error) (bool, error)
 
-// Do makes the actual request for listing all collections. If the request is successful then fn is called sequentially
+// Do make the actual request for listing all collections. If the request is successful then fn is called sequentially
 // with every collection received. But if there is some error/bad response then fn is called with the error. If fn
 // returns false then the whole process is aborted otherwise the request is retried. NOTE: Policies if any returned are
 // ignored as of now. Later if we find them important then we can include them too.
@@ -87,7 +87,7 @@ func (cl *CollectionsListClient) Do(ctx context.Context, fn CollectionsListFn) e
 		copy := cl.sl.New().QueryStruct(params)
 
 		// Make the request and see if there is an error/bad response. If there is one then give fn the error ask for
-		// its intention. If fn still wants to continue the we abort further processing in current iteration and
+		// its intention. If fn still wants to continue the abort further processing in current iteration and
 		// basically retry the same request again.
 		br, err := request(ctx, copy, success)
 		if err != nil {
@@ -104,16 +104,16 @@ func (cl *CollectionsListClient) Do(ctx context.Context, fn CollectionsListFn) e
 		}
 
 		// If we are here then it means there was no error/bad response while fetching current page
-		// so lets iterate over page items.
+		// so let's iterate over page items.
 		for _, col := range success.Data {
 			if ok, e := fn(col, nil); !ok {
 				return e
 			}
 		}
 
-		// If there are more than one items in current list then there could be more items remaining to be fetched. In
+		// If there are more than one item in current list then there could be more items remaining to be fetched. In
 		// that case we adjust offset for next request. If there are no items or just a single item in the list that
-		// means there are no more items to be fetched and we are done.
+		// means there are no more items to be fetched, and we are done.
 		if len(success.Data) <= 1 {
 			return nil
 		}

--- a/collections.go
+++ b/collections.go
@@ -44,7 +44,7 @@ func newCollectionsGetClient(sl *sling.Sling, id CollectionID) *CollectionsGetCl
 	return &CollectionsGetClient{sl: copy}
 }
 
-// Do make the actual request for fetching said collection info.
+// Do makes the actual request for fetching said collection info.
 func (cl *CollectionsGetClient) Do(ctx context.Context) (*Collection, error) {
 	success := &struct {
 		Data *Collection `json:"data"`
@@ -75,7 +75,7 @@ func newCollectionListClient(sl *sling.Sling) *CollectionsListClient {
 // CollectionsListFn is the type of function called by [CollectionsListClient.Do] for every new collecion it finds.
 type CollectionsListFn func(*Collection, error) (bool, error)
 
-// Do make the actual request for listing all collections. If the request is successful then fn is called sequentially
+// Do makes the actual request for listing all collections. If the request is successful then fn is called sequentially
 // with every collection received. But if there is some error/bad response then fn is called with the error. If fn
 // returns false then the whole process is aborted otherwise the request is retried. NOTE: Policies if any returned are
 // ignored as of now. Later if we find them important then we can include them too.
@@ -91,7 +91,7 @@ func (cl *CollectionsListClient) Do(ctx context.Context, fn CollectionsListFn) e
 		copy := cl.sl.New().QueryStruct(params)
 
 		// Make the request and see if there is an error/bad response. If there is one then give fn the error ask for
-		// its intention. If fn still wants to continue the abort further processing in current iteration and
+		// its intention. If fn still wants to continue then we abort further processing in current iteration and
 		// basically retry the same request again.
 		br, err := request(ctx, copy, success)
 		if err != nil {
@@ -115,7 +115,7 @@ func (cl *CollectionsListClient) Do(ctx context.Context, fn CollectionsListFn) e
 			}
 		}
 
-		// If there are more than one item in current list then there could be more items remaining to be fetched. In
+		// If there is more than one item in current list then there could be more items remaining to be fetched. In
 		// that case we adjust offset for next request. If there are no items or just a single item in the list that
 		// means there are no more items to be fetched, and we are done.
 		if len(success.Data) <= 1 {

--- a/common.go
+++ b/common.go
@@ -10,8 +10,8 @@ import (
 	"github.com/dghubble/sling"
 )
 
-// badResponse contains details of bad HTTP response returned by the server. For now we are treating all bad responses
-// as plain text just to be able to print/log. Later if need to examine it further then we can convert it into proper
+// badResponse contains details of bad HTTP response returned by the server. For now, we are treating all bad responses
+// as plain text just to be able to print/log. Later if you need to examine it further than we can convert it into proper
 // concrete type.
 type badResponse struct {
 	clientErr string // only filled in case of 4XX response
@@ -59,7 +59,7 @@ func (ae *apiError) Error() string {
 	return fmt.Sprintf("%+v", ae.br)
 }
 
-// Temporary returns true for 5XX errors. This satifies the temporary interface and enables usage with
+// Temporary returns true for 5XX errors. This satisfies the temporary interface and enables usage with
 // [outline.IsTemporary].
 func (ae *apiError) Temporary() bool {
 	return ae.br.status >= http.StatusInternalServerError && ae.br.status != http.StatusNotImplemented

--- a/documents.go
+++ b/documents.go
@@ -10,7 +10,7 @@ func (cl *DocumentsClient) Get() *DocumentsClientGet {
 	return nil
 }
 
-// GetAll returns a client for retriving multiple documents at once.
+// GetAll returns a client for retrieving multiple documents at once.
 func (cl *DocumentsClient) GetAll() *DocumentsClientGetAll {
 	return nil
 }
@@ -23,7 +23,7 @@ func (cl *DocumentsClientGet) ByID(id DocumentID) *DocumentsClientGet {
 	return nil
 }
 
-// GetByID configures that document be retrieved by its share id.
+// ByShareID configures that document be retrieved by its share id.
 func (cl *DocumentsClientGet) ByShareID(id DocumentShareID) *DocumentsClientGet {
 	return nil
 }
@@ -32,7 +32,7 @@ func (cl *DocumentsClientGet) ByShareID(id DocumentShareID) *DocumentsClientGet 
 func (cl *DocumentsClientGet) Do(ctx context.Context) (*Document, error) { return nil, nil }
 
 // DocumentsClientGetAll can be used to retrieve more than one document. Use available configuration options to select
-// the documents you want to retrive then finall call [DocumentsClientGetAll.Do].
+// the documents you want to retrieve then finally call [DocumentsClientGetAll.Do].
 type DocumentsClientGetAll struct{}
 
 // Collection selects documents belonging to the collection identified by id.

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -19,3 +19,7 @@ func CollectionsGetEndpoint() string {
 func CollectionsListEndpoint() string {
 	return "collections.list"
 }
+
+func CollectionsCreateEndpoint() string {
+	return "collections.create"
+}

--- a/models.go
+++ b/models.go
@@ -7,6 +7,7 @@ type (
 	DocumentShareID string
 	DocumentUrlID   string
 	CollectionID    string
+	CollectionName  string
 )
 
 // Document represents an outline document.

--- a/models.go
+++ b/models.go
@@ -7,7 +7,6 @@ type (
 	DocumentShareID string
 	DocumentUrlID   string
 	CollectionID    string
-	CollectionName  string
 )
 
 // Document represents an outline document.

--- a/package_test.go
+++ b/package_test.go
@@ -162,6 +162,40 @@ func TestClientCollectionsList(t *testing.T) {
 	assert.Equal(t, uint32(3), collectionsListFnCalled.Load())
 }
 
+func TestClientCollectionsCreate(t *testing.T) {
+	testResponse := exampleCollectionsGetResponse
+
+	hc := &http.Client{}
+	hc.Transport = &testutils.MockRoundTripper{RoundTripFn: func(r *http.Request) (*http.Response, error) {
+		// Assert request method and URL.
+		assert.Equal(t, http.MethodPost, r.Method)
+		u, err := url.JoinPath(testBaseURL, common.CollectionsCreateEndpoint())
+		require.NoError(t, err)
+		assert.Equal(t, u, r.URL.String())
+
+		testAssertHeaders(t, r.Header)
+		testAssertBody(t, r, fmt.Sprintf(`{"name":"%s"}`, "new collection"))
+
+		return &http.Response{
+			Request:       r,
+			StatusCode:    http.StatusOK,
+			ContentLength: -1,
+			Body:          io.NopCloser(strings.NewReader(exampleCollectionsGetResponse)),
+		}, nil
+	}}
+
+	cl := outline.New(testBaseURL, hc, testApiKey)
+	got, err := cl.Collections().Create("new collection").Do(context.Background())
+	require.NoError(t, err)
+
+	// Manually unmarshal test response and see if we get same object via the API.
+	expected := &struct {
+		Data outline.Collection `json:"data"`
+	}{}
+	require.NoError(t, json.Unmarshal([]byte(testResponse), expected))
+	assert.Equal(t, &expected.Data, got)
+}
+
 func testAssertHeaders(t *testing.T, headers http.Header) {
 	t.Helper()
 	assert.Equal(t, headers.Get(common.HdrKeyAccept), common.HdrValueAccept)


### PR DESCRIPTION
Does not fix anything, but is somewhat part of #14 
This adds the support for the HTTP client to *create* a collection.

https://www.getoutline.com/developers#tag/Collections/paths/~1collections.create/post

Only "name" is required, so I added it.
We can later adjust it. Not sure (yet) what the default value for `private` is.
I assume it is `true`, but if not, we should add it to the request and make it later configurable. 

I also fixed a few typos suggested by my IDE :)