### PR TITLE
Some CI fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
 name: Test
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [ '1.19.x', '1.20.x' ]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
I noticed that we currently run test two times on PRs.
One because of the `pull_request` trigger, and one because of the `push` trigger.
I fixed it by running 
* on each pull_request
* on push limited to the `main` branch

I also added Go 1.20 to the test matrix.
Even though I don't know if we want to test different variants of Go 🤷 