### PR TITLE
Create workflow to build cli and publish it to artifacts

### DIFF
--- a/.github/workflows/build_cli.yml
+++ b/.github/workflows/build_cli.yml
@@ -1,0 +1,27 @@
+name: Build CLI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  buildCliAndPublish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Build cli
+        run: |
+          GOOS=linux GOARCH=amd64 go build -o clis/outcli-linux ./cli
+          GOOS=darwin GOARCH=amd64 go build -o clis/outcli-macos-x86 ./cli
+          GOOS=darwin GOARCH=arm64 go build -o clis/outcli-macos-silicon ./cli
+      - uses: actions/upload-artifact@v3
+        with:
+          name: outline-clis
+          path: clis/


### PR DESCRIPTION
This workflow will run on each PR and on push to the main branch.
It will buld the cli and publish to the GitHub artifacts.
From there, we can simply download it and "test it", in case we want to 🙃 

What do you think?

Checkout [﻿﻿this](https://github.com/ioki-mobility/go-outline/actions/runs/5683736737) how it looks like :) 
After downloading the `zip`, you only have to give them executable permissions.  