### PR TITLE
Add support for creating a collection [cli]

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,7 +24,7 @@ func Run() error {
 }
 
 func rootCmd() *cobra.Command {
-	var rootCmd = &cobra.Command{Use: "outline"}
+	rootCmd := &cobra.Command{Use: "outline"}
 
 	var apiKeyFlag string
 	var baseUrlFlag string
@@ -45,7 +45,7 @@ func collectionCmd(rootCmd *cobra.Command) *cobra.Command {
 	fetchSubCmd := collectionCmdFetch(rootCmd)
 	collectionCmd.AddCommand(fetchSubCmd)
 
-	createSubCmd := collectionCmdCrate(rootCmd)
+	createSubCmd := collectionCmdCreate(rootCmd)
 	collectionCmd.AddCommand(createSubCmd)
 
 	return collectionCmd
@@ -73,7 +73,7 @@ func collectionCmdFetch(rootCmd *cobra.Command) *cobra.Command {
 					return fmt.Errorf("can't get collection with id '%s': %w", colId, err)
 				}
 
-				b, err := json.Marshal(&col)
+				b, err := json.Marshal(col)
 				if err != nil {
 					return fmt.Errorf("failed marshalling collection with id '%s: %w", colId, err)
 				}
@@ -84,7 +84,7 @@ func collectionCmdFetch(rootCmd *cobra.Command) *cobra.Command {
 	}
 }
 
-func collectionCmdCrate(rootCmd *cobra.Command) *cobra.Command {
+func collectionCmdCreate(rootCmd *cobra.Command) *cobra.Command {
 	return &cobra.Command{
 		Use:   "create",
 		Short: "Creates a collection",
@@ -107,7 +107,7 @@ func collectionCmdCrate(rootCmd *cobra.Command) *cobra.Command {
 				return fmt.Errorf("can't create collection with name '%s': %w", name, err)
 			}
 
-			b, err := json.Marshal(&col)
+			b, err := json.Marshal(col)
 			if err != nil {
 				return fmt.Errorf("failed marshalling collection with name '%s: %w", name, err)
 			}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -45,13 +45,16 @@ func collectionCmd(rootCmd *cobra.Command) *cobra.Command {
 	fetchCommand := collectionCmdFetch(rootCmd)
 	collectionCmd.AddCommand(fetchCommand)
 
+	createCommand := collectionCmdCrate(rootCmd)
+	collectionCmd.AddCommand(createCommand)
+
 	return collectionCmd
 }
 
 func collectionCmdFetch(rootCmd *cobra.Command) *cobra.Command {
 	return &cobra.Command{
 		Use:   "fetch",
-		Short: "Fetch collection details for given ID",
+		Short: "Fetch collection details",
 		Long:  "Fetch collection details for given ID and prints as json to stdout",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -79,6 +82,43 @@ func collectionCmdFetch(rootCmd *cobra.Command) *cobra.Command {
 				}
 				fmt.Println(string(b))
 			}
+			return nil
+		},
+	}
+}
+
+func collectionCmdCrate(rootCmd *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:   "create",
+		Short: "Creates a collection",
+		Long:  "Creates a collection with the given name and prints the result as json to stdout",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			baseUrl, err := rootCmd.Flags().GetString(flagNameBaseUrl)
+			if err != nil {
+				return fmt.Errorf("required flag '%s' not set: %w", flagNameBaseUrl, err)
+			}
+			apiKey, err := rootCmd.Flags().GetString(flagNameApiKey)
+			if err != nil {
+				return fmt.Errorf("required flag '%s' not set: %w", flagNameApiKey, err)
+			}
+			client := outline.New(baseUrl, &http.Client{}, apiKey)
+
+			collectionName := args[0]
+			collection, err := client.
+				Collections().
+				Create(collectionName).
+				Do(context.Background())
+			if err != nil {
+				return fmt.Errorf("can't create collection with name '%s': %w", collectionName, err)
+			}
+
+			b, err := json.Marshal(&collection)
+			if err != nil {
+				return fmt.Errorf("failed marshalling collection with name '%s: %w", collectionName, err)
+			}
+			fmt.Println(string(b))
+
 			return nil
 		},
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -42,11 +42,11 @@ func collectionCmd(rootCmd *cobra.Command) *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 	}
 
-	fetchCommand := collectionCmdFetch(rootCmd)
-	collectionCmd.AddCommand(fetchCommand)
+	fetchSubCmd := collectionCmdFetch(rootCmd)
+	collectionCmd.AddCommand(fetchSubCmd)
 
-	createCommand := collectionCmdCrate(rootCmd)
-	collectionCmd.AddCommand(createCommand)
+	createSubCmd := collectionCmdCrate(rootCmd)
+	collectionCmd.AddCommand(createSubCmd)
 
 	return collectionCmd
 }
@@ -67,18 +67,15 @@ func collectionCmdFetch(rootCmd *cobra.Command) *cobra.Command {
 				return fmt.Errorf("required flag '%s' not set: %w", flagNameApiKey, err)
 			}
 			client := outline.New(baseUrl, &http.Client{}, apiKey)
-			for _, collectionId := range args {
-				collection, err := client.
-					Collections().
-					Get(outline.CollectionID(collectionId)).
-					Do(context.Background())
+			for _, colId := range args {
+				col, err := client.Collections().Get(outline.CollectionID(colId)).Do(context.Background())
 				if err != nil {
-					return fmt.Errorf("can't get collection with id '%s': %w", collectionId, err)
+					return fmt.Errorf("can't get collection with id '%s': %w", colId, err)
 				}
 
-				b, err := json.Marshal(&collection)
+				b, err := json.Marshal(&col)
 				if err != nil {
-					return fmt.Errorf("failed marshalling collection with id '%s: %w", collectionId, err)
+					return fmt.Errorf("failed marshalling collection with id '%s: %w", colId, err)
 				}
 				fmt.Println(string(b))
 			}
@@ -104,18 +101,15 @@ func collectionCmdCrate(rootCmd *cobra.Command) *cobra.Command {
 			}
 			client := outline.New(baseUrl, &http.Client{}, apiKey)
 
-			collectionName := args[0]
-			collection, err := client.
-				Collections().
-				Create(collectionName).
-				Do(context.Background())
+			name := args[0]
+			col, err := client.Collections().Create(name).Do(context.Background())
 			if err != nil {
-				return fmt.Errorf("can't create collection with name '%s': %w", collectionName, err)
+				return fmt.Errorf("can't create collection with name '%s': %w", name, err)
 			}
 
-			b, err := json.Marshal(&collection)
+			b, err := json.Marshal(&col)
 			if err != nil {
-				return fmt.Errorf("failed marshalling collection with name '%s: %w", collectionName, err)
+				return fmt.Errorf("failed marshalling collection with name '%s: %w", name, err)
 			}
 			fmt.Println(string(b))
 


### PR DESCRIPTION
Fixes #14 

This is just a basic usage of creating a collection.
The only supported option is the required "name".

Optional stuff will be added later.
Reference #29 

```
./cli collection create [name] --apiKey [TOKEN] --baseUrl [URL]
```

You can check our internal outline instace for the collection named "stefmaTest". 
This was done via the API:
```
{"id":"1aa656ac-b01f-4a5c-a35d-619aef20c36f","name":"stefmaTest","description":"","sort":{"direction":"asc","field":"index"},"index":"  8","color":"#FFBE0B","icon":"","permission":"","createdAt":"2023-08-04T11:02:37.635Z","updatedAt":"2023-08-04T11:02:37.635Z","deletedAt":"0001-01-01T00:00:00Z"}
```

You could also check this via the CLI 🤓 
```
./cli collection fetch 1aa656ac-b01f-4a5c-a35d-619aef20c36f --apiKey [TOKEN] --baseUrl [URL]
```