### PR TITLE
FIX: wrong go version setup for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
Missing quotes around go version seem to be  the issue. Instead of `1.20` the action was setting up `1.2.2` not sure why :(

See: https://github.com/ioki-mobility/go-outline/actions/runs/5928030596