### PR TITLE
CLI support for list collections

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rsjethani/rsling"
 	"github.com/ioki-mobility/go-outline/internal/common"
+	"github.com/rsjethani/rsling"
 )
 
 // CollectionsClient exposes CRUD operations around the collections resource.
@@ -114,7 +114,7 @@ func newCollectionListClient(sl *rsling.Sling) *CollectionsListClient {
 	return &CollectionsListClient{sl: copy}
 }
 
-// CollectionsListFn is the type of function called by [CollectionsListClient.Do] for every new collecion it finds.
+// CollectionsListFn is the type of function called by [CollectionsListClient.Do] for every new collection it finds.
 type CollectionsListFn func(*Collection, error) (bool, error)
 
 // Do makes the actual request for listing all collections. If the request is successful then fn is called sequentially

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -77,10 +77,20 @@ func parseCmd() *cobra.Command {
 		},
 	}
 
+	collectionListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all collections",
+		Long:  "Get a list of all collections.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return collectionList(cfg.serverUrl, cfg.apiKey)
+		},
+	}
+
 	rootCmd.AddCommand(collectionCmd)
 	collectionCmd.AddCommand(collectionInfoCmd)
 	collectionCmd.AddCommand(collectionCreateCmd)
 	collectionCmd.AddCommand(collectionDocumentsCmd)
+	collectionCmd.AddCommand(collectionListCmd)
 
 	return rootCmd
 }
@@ -132,5 +142,27 @@ func collectionDocuments(serverUrl string, apiKey string, ids []string) error {
 		}
 		fmt.Println(string(b))
 	}
+	return nil
+}
+
+func collectionList(serverUrl string, apiKey string) error {
+	oc := outline.New(serverUrl, &http.Client{}, apiKey)
+	err := oc.Collections().List().Do(context.Background(), func(col *outline.Collection, err error) (bool, error) {
+		if err != nil {
+			return false, err
+		}
+
+		b, err := json.MarshalIndent(col, "", "  ")
+		if err != nil {
+			return false, fmt.Errorf("failed marshalling collection: %w", err)
+		}
+		fmt.Println(string(b))
+
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("can't get list of collections: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
```
./outline collection list --server [Server] --key [Key]
```

For now we are going to ignore errors.. as I'm not sure what kind of errors we have and how to handle them hoenstly 😅 
I guess client errors or something should be returned.. But getting an "malformed collection" or something shouldn't be returned?! 🤔 

So how can I district between those two errors?! 🤔 