### PR TITLE
[HTTP & CLI] Get document 

### DIFF
--- a/documents.go
+++ b/documents.go
@@ -18,7 +18,7 @@ func newDocumentsClient(sl *rsling.Sling) *DocumentsClient {
 	return &DocumentsClient{sl: sl}
 }
 
-// Get returns a client for retriving a single document.
+// Get returns a client for retrieving a single document.
 func (cl *DocumentsClient) Get() *DocumentsClientGet {
 	return nil
 }

--- a/documents.go
+++ b/documents.go
@@ -20,7 +20,8 @@ func newDocumentsClient(sl *rsling.Sling) *DocumentsClient {
 
 // Get returns a client for retrieving a single document.
 func (cl *DocumentsClient) Get() *DocumentsClientGet {
-	return nil
+	params := documentsGetParams{}
+	return &DocumentsClientGet{sl: cl.sl, params: params}
 }
 
 // GetAll returns a client for retrieving multiple documents at once.
@@ -40,21 +41,48 @@ func (cl *DocumentsClient) Update(id DocumentID) *DocumentsUpdateClient {
 	return newDocumentsUpdateClient(cl.sl, id)
 }
 
+// documentsCreateParams represents the Outline Documents.create parameters
+type documentsGetParams struct {
+	DocumentId DocumentID      `json:"id,omitempty"`
+	ShareId    DocumentShareID `json:"shareId,omitempty"`
+}
+
 // DocumentsClientGet gets a single document.
-type DocumentsClientGet struct{}
+type DocumentsClientGet struct {
+	sl     *rsling.Sling
+	params documentsGetParams
+}
 
 // ByID configures that document be retrieved by its id.
 func (cl *DocumentsClientGet) ByID(id DocumentID) *DocumentsClientGet {
-	return nil
+	cl.params.DocumentId = id
+	return cl
 }
 
 // ByShareID configures that document be retrieved by its share id.
 func (cl *DocumentsClientGet) ByShareID(id DocumentShareID) *DocumentsClientGet {
-	return nil
+	cl.params.ShareId = id
+	return cl
 }
 
 // Do makes the actual request and returns the document.
-func (cl *DocumentsClientGet) Do(ctx context.Context) (*Document, error) { return nil, nil }
+func (cl *DocumentsClientGet) Do(ctx context.Context) (*Document, error) {
+	cl.sl.Post(common.DocumentsGetEndpoint()).BodyJSON(&cl.params)
+
+	success := &struct {
+		Data *Document `json:"data"`
+	}{}
+
+	br, err := request(ctx, cl.sl, success)
+	if err != nil {
+		return nil, fmt.Errorf("failed making HTTP request: %w", err)
+	}
+	if br != nil {
+		return nil, fmt.Errorf("bad response: %w", &apiError{br: *br})
+	}
+
+	return success.Data, nil
+}
 
 // DocumentsClientGetAll can be used to retrieve more than one document. Use available configuration options to select
 // the documents you want to retrieve then finally call [DocumentsClientGetAll.Do].

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -34,6 +34,10 @@ func CollectionsCreateEndpoint() string {
 	return "collections.create"
 }
 
+func DocumentsGetEndpoint() string {
+	return "documents.info"
+}
+
 func DocumentsCreateEndpoint() string {
 	return "documents.create"
 }


### PR DESCRIPTION
Fixes hafly #34
It implements the "Get document" command for http and cli.

Noteworthy: 
I also changed the "cli style" here (for this command only).
Instead of using an argument, I used an flag to put either the `id` or the `shareId` to it... 
I'm not 100% sure if this correct 🤷 
But I want to refer this to the discussion here https://github.com/ioki-mobility/go-outline/discussions/58
I guess we should always use flags instead of args?!? 🤔 

```
go run ./cli document get --id 70586bf7-2268-4f47-a61b-9bff33a344e0 --key [KEY] --server [URL]
```
The `id` is an valid internal url. You can directly try it out 🙃 