### PR TITLE
Autogenerate CLI docs and sanitize README

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,21 @@ on:
       - main
 
 jobs:
+  cli-docs-up-to-date:
+    name: cli-docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.19'
+          cache: false
+      - name: Refresh CLI docs
+        run: go run internal/cli-docgen.go
+
+      - name: Verify whether CLI documentation is up-to-date
+        run: git diff --exit-code
+
   # Reference: https://github.com/golangci/golangci-lint-action
   golangci-lint:
     name: linting

--- a/README.md
+++ b/README.md
@@ -2,29 +2,17 @@
 [![MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/ioki-mobility/go-outline/blob/main/LICENSE)
 
 # go-outline
+The module provides Go client and cli for [outline](https://www.getoutline.com/).
 
-Go client and cli for [outline](https://www.getoutline.com/).
+# Go Client
+The Go client provides easy to use API around [outline's official HTTP API](https://www.getoutline.com/developers).
 
-# Installation
-
-## Installing the client:
+## Installation
 ```shell
 go get github.com/ioki-mobility/go-outline
 ```
-
-## Installing the CLI:
-- Download pre-built binaries from [releases](https://github.com/ioki-mobility/go-outline/releases) page for your platform
-- Install via go toolchain:
-```shell
-go install github.com/ioki-mobility/go-outline/cli@latest
-```
-
-# Usage
-
-## Client
-
+## Usage Examples
 ### Create a client
-
 ```go
 cl := outline.New("https://server.url", &http.Client{}, "api key")
 ```
@@ -32,7 +20,6 @@ cl := outline.New("https://server.url", &http.Client{}, "api key")
 > **Note**: You can create a new API key in your outline **account settings**.
 
 ### Get a collection
-
 ```go
 col, err := cl.Collections().Get("collection id").Do(context.Background())
 if err != nil {
@@ -41,9 +28,7 @@ if err != nil {
 fmt.Println(col)
 ```
 
-
 ### Get all collections
-
 ```go
 err := cl.Collections().List().Do(context.Background(), func(col *outline.Collection, err error) (bool, error) {
 	fmt.Println(col)
@@ -55,7 +40,6 @@ if err != nil {
 ```
 
 ### Create a collection
-
 ```go
 col, err := cl.Collections().Create("collection name").Do(context.Background()) 
 if err != nil {
@@ -76,7 +60,6 @@ colCreateClient.
 ```
 
 ### Document Create
-
 ```go
 doc := cl.Documents().Create("Document name", "collection id").Do(context.Background())
 ```
@@ -93,37 +76,14 @@ docCreateClient.
 	Do(context.Background())
 ```
 
-## CLI
 
-### Build the CLI
-
-```
-go build -o outline ./cli
-```
-
-### Required flags
-
-Any command requires the flags `server` and `key`.
-You can simply add them with `--server https://server.url` 
-and `--key sup3rS3cre7Ap1K3Y`.
-
-### Collections
-
-The basic command to work with collections is:
-```
-outline collections
+# CLI
+## Installation
+- Download pre-built binaries from [releases](https://github.com/ioki-mobility/go-outline/releases) page
+- Install via go toolchain:
+```shell
+go install github.com/ioki-mobility/go-outline/cli@latest
 ```
 
-#### Collections fetch
-
-To fetch a collection and display it in a json string use:
-```
-outline collections fetch [COLLECTION_ID] [flags]
-```
-
-#### Collections create
-
-To create a collection and display the created collection as a json string use:
-```
-outline collections create [COLLECTION_NAME] [flags]
-```
+## Usage
+[Latest cli docs.](./cli/docs/outcli.md)

--- a/cli/docs/outcli.md
+++ b/cli/docs/outcli.md
@@ -1,0 +1,18 @@
+## outcli
+
+
+
+### Options
+
+```
+  -h, --help            help for outcli
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli collection](outcli_collection.md)	 - Work with collections
+* [outcli document](outcli_document.md)	 - Work with documents
+* [outcli version](outcli_version.md)	 - Show app version
+

--- a/cli/docs/outcli_collection.md
+++ b/cli/docs/outcli_collection.md
@@ -1,0 +1,29 @@
+## outcli collection
+
+Work with collections
+
+### Synopsis
+
+If you have to work with collection in any case, use this command
+
+### Options
+
+```
+  -h, --help   help for collection
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli](outcli.md)	 - 
+* [outcli collection create](outcli_collection_create.md)	 - Creates a collection
+* [outcli collection docs](outcli_collection_docs.md)	 - Get document structure
+* [outcli collection info](outcli_collection_info.md)	 - Get collection info
+* [outcli collection list](outcli_collection_list.md)	 - List all collections
+

--- a/cli/docs/outcli_collection_create.md
+++ b/cli/docs/outcli_collection_create.md
@@ -1,0 +1,29 @@
+## outcli collection create
+
+Creates a collection
+
+### Synopsis
+
+Creates a collection with the given name and prints the result as json to stdout
+
+```
+outcli collection create [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli collection](outcli_collection.md)	 - Work with collections
+

--- a/cli/docs/outcli_collection_docs.md
+++ b/cli/docs/outcli_collection_docs.md
@@ -1,0 +1,29 @@
+## outcli collection docs
+
+Get document structure
+
+### Synopsis
+
+Get a summary of associated documents (and children)
+
+```
+outcli collection docs [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for docs
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli collection](outcli_collection.md)	 - Work with collections
+

--- a/cli/docs/outcli_collection_info.md
+++ b/cli/docs/outcli_collection_info.md
@@ -1,0 +1,29 @@
+## outcli collection info
+
+Get collection info
+
+### Synopsis
+
+Get information about the collection
+
+```
+outcli collection info [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for info
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli collection](outcli_collection.md)	 - Work with collections
+

--- a/cli/docs/outcli_collection_list.md
+++ b/cli/docs/outcli_collection_list.md
@@ -1,0 +1,29 @@
+## outcli collection list
+
+List all collections
+
+### Synopsis
+
+Get a list of all collections.
+
+```
+outcli collection list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli collection](outcli_collection.md)	 - Work with collections
+

--- a/cli/docs/outcli_document.md
+++ b/cli/docs/outcli_document.md
@@ -1,0 +1,28 @@
+## outcli document
+
+Work with documents
+
+### Synopsis
+
+If you have to work with documents in any case, use this command
+
+### Options
+
+```
+  -h, --help   help for document
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli](outcli.md)	 - 
+* [outcli document create](outcli_document_create.md)	 - Creates a document
+* [outcli document get](outcli_document_get.md)	 - Get an existing document by its ID
+* [outcli document update](outcli_document_update.md)	 - Update an existing document
+

--- a/cli/docs/outcli_document_create.md
+++ b/cli/docs/outcli_document_create.md
@@ -1,0 +1,29 @@
+## outcli document create
+
+Creates a document
+
+### Synopsis
+
+Creates a collection with the given name and collection id
+
+```
+outcli document create [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli document](outcli_document.md)	 - Work with documents
+

--- a/cli/docs/outcli_document_get.md
+++ b/cli/docs/outcli_document_get.md
@@ -1,0 +1,30 @@
+## outcli document get
+
+Get an existing document by its ID
+
+### Synopsis
+
+Get information about an existing document by specifying its document ID or a share ID
+
+```
+outcli document get [flags]
+```
+
+### Options
+
+```
+  -h, --help    help for get
+      --share   Treat the argument as document share iD
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli document](outcli_document.md)	 - Work with documents
+

--- a/cli/docs/outcli_document_update.md
+++ b/cli/docs/outcli_document_update.md
@@ -1,0 +1,33 @@
+## outcli document update
+
+Update an existing document
+
+### Synopsis
+
+Update an existing document's title, text etc. properties
+
+```
+outcli document update [flags]
+```
+
+### Options
+
+```
+      --append         Append new text to existing rather than replacing it
+  -h, --help           help for update
+      --publish        Whether this document should be published and made visible to other team members, if a draft
+      --text           Read document text from stdin
+      --title string   The title of the document
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli document](outcli_document.md)	 - Work with documents
+

--- a/cli/docs/outcli_version.md
+++ b/cli/docs/outcli_version.md
@@ -1,0 +1,25 @@
+## outcli version
+
+Show app version
+
+```
+outcli version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli](outcli.md)	 - 
+

--- a/cli/main.go
+++ b/cli/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	if err := cli.Run(); err != nil {
+	if err := cli.Command().Execute(); err != nil {
 		fmt.Println("fatal error: ", err)
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,12 @@ require (
 )
 
 require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -11,6 +12,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rsjethani/rsling v0.2.0 h1:a8OY4aCDN/FqnKgF9/FHdyoLB90frXcaXEREdg139u0=
 github.com/rsjethani/rsling v0.2.0/go.mod h1:vgWZR0je3w8oCWjV4C9KjwzkSMf8Wy0QWjvTY3ssJrE=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=

--- a/internal/cli-docgen.go
+++ b/internal/cli-docgen.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ioki-mobility/go-outline/internal/cli"
+	"github.com/spf13/cobra/doc"
+)
+
+func main() {
+	cmd := cli.Command()
+	if err := doc.GenMarkdownTree(cmd, "./cli/docs"); err != nil {
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,17 +18,16 @@ const (
 	flagApiKey    = "key"
 )
 
-func Run() error {
-	return parseCmd().Execute()
-}
-
 type config struct {
 	serverUrl string
 	apiKey    string
 }
 
-func parseCmd() *cobra.Command {
-	rootCmd := &cobra.Command{Use: "outline"}
+func Command() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:               "outcli",
+		DisableAutoGenTag: true,
+	}
 
 	var cfg config
 	rootCmd.PersistentFlags().StringVar(&cfg.serverUrl, flagServerURL, "", "The outline API server url")


### PR DESCRIPTION
We leverage https://pkg.go.dev/github.com/spf13/cobra/doc for
autogenerating CLI docs in markdown format. We also add github workflow
to make sure that up-to-date docs are also required to merge cli code
changes.

README was updated to have better structure and remove old info. Also we
now refer to cli with its correct name `outcli` in docs also.

NOTE: Even though we are now auto-generating docs, the comment/doc
strings in commands still need to be improved in a future PR.

Closes #46 