### PR TITLE
Support for update collections

### DIFF
--- a/cli/docs/outcli_collection.md
+++ b/cli/docs/outcli_collection.md
@@ -26,4 +26,5 @@ If you have to work with collection in any case, use this command
 * [outcli collection docs](outcli_collection_docs.md)	 - Get document structure
 * [outcli collection info](outcli_collection_info.md)	 - Get collection info
 * [outcli collection list](outcli_collection_list.md)	 - List all collections
+* [outcli collection update](outcli_collection_update.md)	 - Update an existing collection
 

--- a/cli/docs/outcli_collection_update.md
+++ b/cli/docs/outcli_collection_update.md
@@ -1,0 +1,34 @@
+## outcli collection update
+
+Update an existing collection
+
+### Synopsis
+
+Update an existing collection's name, description etc. properties
+
+```
+outcli collection update [flags]
+```
+
+### Options
+
+```
+      --color string            The color of the collection. Should be in the format of #AABBCC
+      --description string      The description of the collection
+  -h, --help                    help for update
+      --name string             The name of the collection
+      --permission_read         Change the permission to read only
+      --permission_read_write   Change the permission to read write
+```
+
+### Options inherited from parent commands
+
+```
+      --key string      The outline api key
+      --server string   The outline API server url
+```
+
+### SEE ALSO
+
+* [outcli collection](outcli_collection.md)	 - Work with collections
+

--- a/cli/docs/outcli_collection_update.md
+++ b/cli/docs/outcli_collection_update.md
@@ -17,8 +17,8 @@ outcli collection update [flags]
       --description string      The description of the collection
   -h, --help                    help for update
       --name string             The name of the collection
-      --permission_read         Change the permission to read only
-      --permission_read_write   Change the permission to read write
+      --permission-read         Change the permission to read only
+      --permission-read-write   Change the permission to read write
 ```
 
 ### Options inherited from parent commands

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -256,8 +256,9 @@ func collectionUpdate() *cobra.Command {
 	cmd.Flags().StringVar(&name, "name", "", "The name of the collection")
 	cmd.Flags().StringVar(&description, "description", "", "The description of the collection")
 	cmd.Flags().StringVar(&color, "color", "", "The color of the collection. Should be in the format of #AABBCC")
-	cmd.Flags().BoolVar(&permissionRead, "permission_read", false, "Change the permission to read only")
-	cmd.Flags().BoolVar(&permissionReadWrite, "permission_read_write", false, "Change the permission to read write")
+	cmd.Flags().BoolVar(&permissionRead, "permission-read", false, "Change the permission to read only")
+	cmd.Flags().BoolVar(&permissionReadWrite, "permission-read-write", false, "Change the permission to read write")
+ cmd.MarkFlagsMutuallyExclusive("permission-read", "permission-read-write")
 
 	return cmd
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -224,7 +224,6 @@ func collectionUpdate() *cobra.Command {
 				return fmt.Errorf("%s: %w", errBase, err)
 			}
 
-			println(name)
 			cl := outline.New(url, &http.Client{}, key).
 				Collections().
 				Update(outline.CollectionID(id)).

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -258,7 +258,7 @@ func collectionUpdate() *cobra.Command {
 	cmd.Flags().StringVar(&color, "color", "", "The color of the collection. Should be in the format of #AABBCC")
 	cmd.Flags().BoolVar(&permissionRead, "permission-read", false, "Change the permission to read only")
 	cmd.Flags().BoolVar(&permissionReadWrite, "permission-read-write", false, "Change the permission to read write")
- cmd.MarkFlagsMutuallyExclusive("permission-read", "permission-read-write")
+	cmd.MarkFlagsMutuallyExclusive("permission-read", "permission-read-write")
 
 	return cmd
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -121,6 +121,7 @@ func Command() *cobra.Command {
 	collectionCmd.AddCommand(collectionCreateCmd)
 	collectionCmd.AddCommand(collectionDocumentsCmd)
 	collectionCmd.AddCommand(collectionListCmd)
+	collectionCmd.AddCommand(collectionUpdate())
 	rootCmd.AddCommand(documentCmd)
 	documentCmd.AddCommand(documentCreateCmd)
 	documentCmd.AddCommand(documentGetCmd)
@@ -198,6 +199,68 @@ func collectionList(serverUrl string, apiKey string) error {
 		return fmt.Errorf("can't get list of collections: %w", err)
 	}
 	return nil
+}
+
+func collectionUpdate() *cobra.Command {
+	var name, description, color string
+	var permissionRead, permissionReadWrite bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update an existing collection",
+		Long:  "Update an existing collection's name, description etc. properties",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			id := args[0]
+			errBase := fmt.Sprintf("failed updating collection with ID '%s'", id)
+
+			// Extract value of global flags
+			key, err := c.Flags().GetString(flagApiKey)
+			if err != nil {
+				return fmt.Errorf("%s: %w", errBase, err)
+			}
+			url, err := c.Flags().GetString(flagServerURL)
+			if err != nil {
+				return fmt.Errorf("%s: %w", errBase, err)
+			}
+
+			println(name)
+			cl := outline.New(url, &http.Client{}, key).
+				Collections().
+				Update(outline.CollectionID(id)).
+				Name(name).
+				Description(description).
+				Color(color)
+
+			if permissionRead {
+				cl.PermissionRead()
+			}
+			if permissionReadWrite {
+				cl.PermissionReadWrite()
+			}
+
+			doc, err := cl.Do(context.Background())
+			if err != nil {
+				return fmt.Errorf("%s: %w", errBase, err)
+			}
+
+			b, err := json.MarshalIndent(doc, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed marshalling collection with ID '%s': %w", id, err)
+			}
+			fmt.Println(string(b))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "The name of the collection")
+	cmd.Flags().StringVar(&description, "description", "", "The description of the collection")
+	cmd.Flags().StringVar(&color, "color", "", "The color of the collection. Should be in the format of #AABBCC")
+	cmd.Flags().BoolVar(&permissionRead, "permission_read", false, "Change the permission to read only")
+	cmd.Flags().BoolVar(&permissionReadWrite, "permission_read_write", false, "Change the permission to read write")
+
+	return cmd
 }
 
 func documentCreate(serverUrl string, apiKey string, name string, collectionId outline.CollectionID) error {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -34,6 +34,10 @@ func CollectionsCreateEndpoint() string {
 	return "collections.create"
 }
 
+func CollectionsUpdateEndpoint() string {
+	return "collections.update"
+}
+
 func DocumentsGetEndpoint() string {
 	return "documents.info"
 }

--- a/package_test.go
+++ b/package_test.go
@@ -203,6 +203,99 @@ func TestClientCollectionsGet(t *testing.T) {
 	assert.Equal(t, &expected.Data, got)
 }
 
+func TestClientCollectionsUpdate_failed(t *testing.T) {
+	tests := map[string]struct {
+		isTemporary bool
+		rt          http.RoundTripper
+	}{
+		"HTTP request failed": {
+			isTemporary: false,
+			rt: &testutils.MockRoundTripper{
+				RoundTripFn: func(r *http.Request) (*http.Response, error) {
+					return nil, &net.DNSError{}
+				},
+			},
+		},
+		"server side error": {
+			isTemporary: true,
+			rt: &testutils.MockRoundTripper{
+				RoundTripFn: func(r *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Request:       r,
+						StatusCode:    http.StatusServiceUnavailable,
+						ContentLength: -1,
+						Body:          io.NopCloser(strings.NewReader("service unavailable")),
+					}, nil
+				},
+			},
+		},
+		"client side error": {
+			isTemporary: false,
+			rt: &testutils.MockRoundTripper{
+				RoundTripFn: func(r *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Request:       r,
+						ContentLength: -1,
+						StatusCode:    http.StatusUnauthorized,
+						Body:          io.NopCloser(strings.NewReader("unauthorized key")),
+					}, nil
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			hc := &http.Client{}
+			hc.Transport = test.rt
+			cl := outline.New(testServerURL, hc, testApiKey)
+			col, err := cl.Collections().Update("collection id").Do(context.Background())
+			assert.Nil(t, col)
+			require.NotNil(t, err)
+			assert.Equal(t, test.isTemporary, outline.IsTemporary(err))
+		})
+	}
+}
+
+func TestClientCollectionsUpdate(t *testing.T) {
+	testResponse := exampleCollectionsUpdateResponse
+
+	// Prepare HTTP client with mocked transport.
+	hc := &http.Client{}
+	hc.Transport = &testutils.MockRoundTripper{RoundTripFn: func(r *http.Request) (*http.Response, error) {
+		// Assert request method and URL.
+		assert.Equal(t, http.MethodPost, r.Method)
+		u, err := url.JoinPath(common.BaseURL(testServerURL), common.CollectionsUpdateEndpoint())
+		require.NoError(t, err)
+		assert.Equal(t, u, r.URL.String())
+
+		testAssertHeaders(t, r.Header)
+		testAssertBody(t, r, fmt.Sprintf(`{"id":"%s", "name":"%s", "description":"%s"}`, "collection id", "NewName", "New Desc"))
+
+		return &http.Response{
+			Request:       r,
+			ContentLength: -1,
+			StatusCode:    http.StatusOK,
+			Body:          io.NopCloser(strings.NewReader(testResponse)),
+		}, nil
+	}}
+
+	cl := outline.New(testServerURL, hc, testApiKey)
+	got, err := cl.Collections().
+		Update("collection id").
+		Name("NewName").
+		Description("New Desc").
+		Do(context.Background())
+	require.NoError(t, err)
+
+	// Manually unmarshal test response and see if we get same object via the API.
+	expected := &struct {
+		Data outline.Collection `json:"data"`
+	}{}
+	require.NoError(t, json.Unmarshal([]byte(testResponse), expected))
+	assert.Equal(t, &expected.Data, got)
+}
+
 func TestClientCollectionsList(t *testing.T) {
 	requestCount := atomic.Uint32{}
 	hc := &http.Client{}
@@ -708,6 +801,8 @@ const exampleCollectionsGetResponse string = `{
     "deletedAt": "2019-08-24T14:15:22Z"
   }
 }`
+
+const exampleCollectionsUpdateResponse string = exampleCollectionsGetResponse
 
 const exampleCollectionsListResponse_2collections string = `
 	{


### PR DESCRIPTION
Fixes #69 

You can run it with:
```
go run ./cli collection update a79983a1-edf5-4a37-affb-2254aecba1a8 --name "Test Outline API Backup Update" --key [KEY] --server [SERVER]

```

> [!NOTE]
> It seems you can only update collections where you have the permission to update. 
> So we can't update our existing "test cli" collections.
> To test it, better first create your own collection and update it afterwards ❗ 
> In case you update an collection where you don't have permission to update, you get the following error message:

```
{clientErr:{"ok":false,"error":"authentication_required","status":401,"message":"Invalid API key"} serverErr: status:401
```

## To test:
1. Create a new collection:
```bash
go run ./cli collection create "New Collection" --key [KEY] --server [SERVER]
```
The response contains the collection id:
```json
{
  "id": "[ID_HERE]",
  "name": "New Collection",
  "description": "",
  "sort": {
    "direction": "asc",
    "field": "index"
  },
  "index": "    P",
  "color": "#42DED1",
  "icon": "",
  "permission": "",
  "createdAt": "2024-02-06T07:17:24.658Z",
  "updatedAt": "2024-02-06T07:17:24.658Z",
  "deletedAt": "0001-01-01T00:00:00Z"
}
```
2. Use the `id` from the newly created collection to update it
```bash
go run ./cli collection update [ID_HERE] --permission-read-write --name "Test Outline API Backup Update" --key [KEY] --server [SERVER]
```
Response should be something like this:
```json
{
  "id": "[ID_HERE]",
  "name": "Test Outline API Backup Update", // Notice the new name!
  "description": "",
  "sort": {
    "direction": "asc",
    "field": "index"
  },
  "index": "    P",
  "color": "#42DED1",
  "icon": "",
  "permission": "read_write", // Notice the new permission
  "createdAt": "2024-02-06T07:17:24.658Z",
  "updatedAt": "2024-02-06T07:17:42.914Z",
  "deletedAt": "0001-01-01T00:00:00Z"
}
```

