### PR TITLE
FIX:goreleaser cannot find main file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,16 +15,14 @@ builds:
   - id: macos
     goos: [darwin]
     goarch: [amd64, arm64]
-    main: ./cli
-    binary: outcli
+    main: ./cmd/outcli
     ldflags:
       - -s -w -X github.com/ioki-mobility/go-outline/internal/common.Version={{ .Tag }}
 
   - id: linux
     goos: [linux]
     goarch: [amd64]
-    main: ./cli
-    binary: outcli
+    main: ./cmd/outcli
     env:
       - CGO_ENABLED=0
     ldflags:
@@ -41,4 +39,3 @@ archives:
     name_template: "outcli_{{ .Tag }}_macOS_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: true
     format: zip
-


### PR DESCRIPTION
In an earlier change https://github.com/ioki-mobility/go-outline/pull/80 we reorganized code somwhow forgot to tell goreleaser about new location of the main package. Hence this change.