### PR TITLE
Fix website building

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -12,14 +12,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Hugo
-        run: sudo apt install hugo
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.124.1' 
 
       - name: Prepare and build website
         run: |
           hugo new site outclidocs
           cd outclidocs
           hugo mod init github.com/ioki-mobility/go-outline
+          hugo mod get github.com/alex-shpak/hugo-book@e104a11f42fbd069aa15606c5f01631b07d7528c # This is tag `v10`
           cp ../cmd/outcli/docs/website/config.toml config.toml
           cp ../cmd/outcli/docs/website/_index.md content/_index.md
           mkdir content/docs

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   buildGitHubPages:


### PR DESCRIPTION
By pinning the Hugo and theme version. 
But also enabled to build the website on demand (with workflow_dispatch)

Explanation:
The theme was just released in version v10.
This require Hugo version 0.124.0.
But the Ubuntu repo has an older version.

So I pin both tools now.
Installing always 0.124.1 of Hugo
And using always the theme v10, regardless of when a new version were released.

~Not tested yet.~
~PR opened via mobile app.~
~Have to check later if it works 😂.~